### PR TITLE
Fix production build error and client-side exceptions

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
     unoptimized: true,
     domains: [], // Add any external image domains here if needed
   },
+  transpilePackages: ['react-phone-input-2'],
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
This commit addresses a `TypeError: Cannot read properties of undefined (reading 'ref')` error that was occurring in the production build.

- The dynamic import for `react-phone-input-2` in `ContactSection.tsx` has been corrected to properly handle the module's default export.
- `next.config.js` has been updated to include `react-phone-input-2` in `transpilePackages`. This ensures the library is correctly processed by Babel during the build, which is a common requirement for libraries not explicitly published as transpiled code.

This also includes the previous fixes:
- Fixed a syntax error in `app/layout.tsx` caused by duplicated code in an inline script.
- Removed extensive and problematic error-suppression scripts.
- Removed multiple unused components and hooks to clean up the codebase.