### PR TITLE
Fix production 'ref' error by removing dynamic imports

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
@@ -8,14 +7,13 @@ import Hero from '@/components/sections/Hero';
 import WhatsAppButton from '@/components/ui/WhatsAppButton';
 import ReviewsSlider from '@/components/sections/ReviewsSlider';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
-
-const AboutOurStory = dynamic(() => import('@/components/sections/AboutOurStory'), { ssr: false });
-const VillasPreview = dynamic(() => import('@/components/sections/VillasPreview'), { ssr: false });
-const GalleryPreview = dynamic(() => import('@/components/sections/GalleryPreview'), { ssr: false });
-const AmenitiesPreview = dynamic(() => import('@/components/sections/AmenitiesPreview'), { ssr: false });
-const LocationPreview = dynamic(() => import('@/components/sections/LocationPreview'), { ssr: false });
-const SocialNetworksSection = dynamic(() => import('@/components/sections/SocialNetworksSection'), { ssr: false });
-const ContactPreview = dynamic(() => import('@/components/sections/ContactPreview'), { ssr: false });
+import AboutOurStory from '@/components/sections/AboutOurStory';
+import VillasPreview from '@/components/sections/VillasPreview';
+import GalleryPreview from '@/components/sections/GalleryPreview';
+import AmenitiesPreview from '@/components/sections/AmenitiesPreview';
+import LocationPreview from '@/components/sections/LocationPreview';
+import SocialNetworksSection from '@/components/sections/SocialNetworksSection';
+import ContactPreview from '@/components/sections/ContactPreview';
 
 export default function Home() {
   return (


### PR DESCRIPTION
This commit resolves a persistent `TypeError: Cannot read properties of undefined (reading 'ref')` that was occurring in production builds.

After multiple failed attempts to fix the issue with specific dynamic imports, this commit takes a more direct approach by replacing all `next/dynamic` imports on the main page (`app/page.tsx`) with standard static imports.

This change has successfully resolved the error, indicating the root cause was within the `next/dynamic` implementation or its interaction with one of the loaded components in a production environment.

While this may slightly increase the initial bundle size, it ensures the application is stable and error-free. The dynamic imports can be re-introduced on a component-by-component basis in the future if performance optimization is required.

This also incorporates all previous cleanup work, including the removal of dead code and faulty error-suppression scripts.